### PR TITLE
Set H2O train fraction to 1

### DIFF
--- a/components/ml/org.wso2.carbon.ml.core/src/main/java/org/wso2/carbon/ml/core/spark/algorithms/StackedAutoencodersClassifier.java
+++ b/components/ml/org.wso2.carbon.ml.core/src/main/java/org/wso2/carbon/ml/core/spark/algorithms/StackedAutoencodersClassifier.java
@@ -70,7 +70,7 @@ public class StackedAutoencodersClassifier implements Serializable {
             String activationType, int epochs, String responseColumn, long modelID) {
         // build stacked autoencoder by training the model with training data
         
-        double trainingFraction = 0.8;
+        double trainingFraction = 1;
         try {
             Scope.enter();
             if (trainData != null) {


### PR DESCRIPTION
Modified H2O training data fraction from 0.8 to 1. 
We need to feed all data that we select for training the model.
