### PR TITLE
add NaN to missing values set

### DIFF
--- a/components/ml/org.wso2.carbon.ml.commons/src/main/java/org/wso2/carbon/ml/commons/constants/MLConstants.java
+++ b/components/ml/org.wso2.carbon.ml.commons/src/main/java/org/wso2/carbon/ml/commons/constants/MLConstants.java
@@ -257,7 +257,7 @@ public class MLConstants {
     }
 
     public enum MISSING_VALUES {
-        EMPTY(""), NA("NA"), QUESTION("?");
+        EMPTY(""), NA("NA"), QUESTION("?"), NAN("NaN");
 
         private final String value;
         private MISSING_VALUES(final String str) {


### PR DESCRIPTION
Some Siddhi functions(ex: stddev) may produce "NaN", if the calculation is failed. Then the Machine Learner may failed to detect such data as missing values. Therefore, set "NaN" to be considered as a missing value.