### PR TITLE
Fix issues in the login page

### DIFF
--- a/apps/ml/site/home/login.jag
+++ b/apps/ml/site/home/login.jag
@@ -145,6 +145,7 @@
                     var authEncoded = btoa(auth)
 
                     $.ajax({
+                        type: "POST",
                         url: './ajax/authenticate.jag',
                         data: {
                             userName: user,

--- a/apps/ml/site/home/login.jag
+++ b/apps/ml/site/home/login.jag
@@ -67,12 +67,12 @@
 
                             <label class="input-label">Username</label>
                             <div class="input-control text">
-                                <input id="userName" type="text" value="" placeholder="your username"/>
+                                <input id="userName" type="text" value="" placeholder="your username" autocomplete="off"/>
                             </div>
 
                             <label class="input-label">Password</label>
                             <div class="input-control text">
-                                <input id="password" type="password" value="" placeholder="your password"/>
+                                <input id="password" type="password" value="" placeholder="your password" autocomplete="off"/>
                             </div>
 
                             <div class="input-control text">

--- a/apps/ml/site/home/login.jag
+++ b/apps/ml/site/home/login.jag
@@ -157,7 +157,8 @@
                         },
                         error: function(res) {
                             console.log(res);
-                            $('.wr-validation-summary').html('<p>' + res.responseJSON.status + '</p>');
+                            $('.wr-validation-summary').html('<p></p>');
+                            $('.wr-validation-summary > p').text(res.responseJSON.status);
                             $('.wr-validation-summary').show();
                         }
                     });


### PR DESCRIPTION
This PR fixes following issues in the login page
- Set `autocomplete="off"` attribute to the username, password inputs
- Change the authenticate AJAX request type to POST
- Do HTML special character escape before setting the response of the authenticate AJAX request to the `<p></p>` tag